### PR TITLE
Add create bucket permission to lambda, fix glue script bug

### DIFF
--- a/profiler/CloudFormationSolution/afd_data_analyzer_cfn_template.yaml
+++ b/profiler/CloudFormationSolution/afd_data_analyzer_cfn_template.yaml
@@ -183,6 +183,16 @@ Resources:
               - logs:PutLogEvents
               Effect: Allow
               Resource: arn:aws:logs:*:*:*
+            - Action:
+              - s3:Get*
+              - s3:List*
+              - s3:Create*
+              - s3:Put*
+              - s3-object-lambda:Get*
+              - s3-object-lambda:List*
+              - s3-object-lambda:Put*
+              Effect: Allow
+              Resource: arn:aws:s3:::*
             Version: '2012-10-17'
           PolicyName: !Sub ${AWS::StackName}-${AWS::Region}-AWSLambda-CW
 

--- a/profiler/CloudFormationSolution/afd_data_analyzer_glue_script.py
+++ b/profiler/CloudFormationSolution/afd_data_analyzer_glue_script.py
@@ -242,10 +242,14 @@ def set_feature(row, config):
         'datetime': 'DATETIME',
         'EMAIL_ADDRESS': 'EMAIL_ADDRESS',
         'IP_ADDRESS': 'IP_ADDRESS',
-        'PHONE_NUMBER': 'PHONE_NUMBER'
+        'PHONE_NUMBER': 'PHONE_NUMBER',
+        'bool': 'CATEGORY'
     }
     
-    feature = dtype_to_vtype_map[row._dtype]
+    if row._dtype in dtype_to_vtype_map:
+        feature = dtype_to_vtype_map[row._dtype]
+    else:
+        feature = ['CATEGORY']
 
     if row._column == required_features['EVENT_TIMESTAMP']:
         feature = "EVENT_TIMESTAMP"
@@ -408,7 +412,10 @@ def get_stats(config, df):
 
 def col_stats(df, target, column, majority,MinClassCount,labels):
     """ generates column statisitcs for categorical columns """
-    cat_summary = df.groupby([column,target])[target].count().unstack(fill_value=0).reset_index().sort_values(majority, ascending=True).reset_index(drop=True)
+    df_temp = df[[column,target]]
+    df_temp[column] = df_temp[column].fillna('<missing>')
+    cat_summary = df_temp.groupby([column,target])[target].count().unstack(fill_value=0).reset_index().sort_values(majority, ascending=True).reset_index(drop=True)
+    
     # Total number of records
     cat_summary['total'] = 0
     sort_orders = []


### PR DESCRIPTION
*Issue #, if available:*
- Lambda misses permission to create bucket, causing errors. 
- Glue script has bugs for datasets with bool datatype and missing values for one label

*Description of changes:*
- Add create bucket permission to lambda.
- Fix glue script bugs. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
