### PR TITLE
Add scripts to shift timestamp

### DIFF
--- a/data/UpdateDatasetTimestamp.ipynb
+++ b/data/UpdateDatasetTimestamp.ipynb
@@ -1,0 +1,152 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3d4fab9e",
+   "metadata": {},
+   "source": [
+    "# Notebook for updating dateset timestamps\n",
+    "Amazon Fraud Detector only retain 18 months of data for ingested events. This notebook provide functions to shift dateset timestamps to most recent months. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e3f51928",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from datetime import datetime, timezone, timedelta\n",
+    "import glob\n",
+    "import zipfile\n",
+    "import os\n",
+    "\n",
+    "def update_timestamp(file):\n",
+    "    # Input: \n",
+    "    #     file: file_path to csv \n",
+    "\n",
+    "    df = pd.read_csv(file,\n",
+    "                dtype='object',\n",
+    "                keep_default_na=False,\n",
+    "                na_values='')\n",
+    "\n",
+    "    df['EVENT_TIMESTAMP'] = pd.to_datetime(df['EVENT_TIMESTAMP'])\n",
+    "    min_dt = min(df['EVENT_TIMESTAMP'])\n",
+    "    max_dt = max(df['EVENT_TIMESTAMP'])\n",
+    "    \n",
+    "    if 'LABEL_TIMESTAMP' in df.columns:\n",
+    "        df['LABEL_TIMESTAMP'] = pd.to_datetime(df['LABEL_TIMESTAMP'])\n",
+    "        min_dt = min(min_dt, df['LABEL_TIMESTAMP'].min())\n",
+    "        max_dt = max(max_dt, df['LABEL_TIMESTAMP'].max())\n",
+    "        \n",
+    "    print('Orignal dates')\n",
+    "    print(min_dt, max_dt)\n",
+    "    \n",
+    "    tz_info = max_dt.tzinfo\n",
+    "\n",
+    "    assert max_dt-min_dt<timedelta(days=547)\n",
+    "\n",
+    "    time_diff = datetime.now(tz_info)-max_dt-timedelta(days=1)\n",
+    "\n",
+    "    df['EVENT_TIMESTAMP'] = df['EVENT_TIMESTAMP'] + time_diff\n",
+    "    print('Updated dates')\n",
+    "    print(df['EVENT_TIMESTAMP'].min(), df['EVENT_TIMESTAMP'].max())\n",
+    "    if 'LABEL_TIMESTAMP' in df.columns:\n",
+    "        df['LABEL_TIMESTAMP'] = df['LABEL_TIMESTAMP'] + time_diff\n",
+    "        print(df['LABEL_TIMESTAMP'].min(), df['LABEL_TIMESTAMP'].max())\n",
+    "        \n",
+    "    df['EVENT_TIMESTAMP'] = df['EVENT_TIMESTAMP'].dt.strftime(\"%Y-%m-%dT%H:%M:%SZ\")\n",
+    "    if 'LABEL_TIMESTAMP' in df.columns:\n",
+    "        df['LABEL_TIMESTAMP'] = df['LABEL_TIMESTAMP'].dt.strftime(\"%Y-%m-%dT%H:%M:%SZ\")\n",
+    "        \n",
+    "    \n",
+    "    df.to_csv(file,index=False)\n",
+    "    return 'SUCCESS'\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abaceeaa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Orignal dates\n",
+      "2021-09-25 13:34:54+00:00 2022-09-25 18:20:17+00:00\n",
+      "Updated dates\n",
+      "2021-09-25 13:35:45.043296+00:00 2022-09-25 18:21:08.043296+00:00\n",
+      "Orignal dates\n",
+      "2021-09-25 13:07:17+00:00 2022-09-25 18:20:17+00:00\n",
+      "Updated dates\n",
+      "2021-09-25 13:08:08.209699+00:00 2022-09-25 18:21:08.209699+00:00\n",
+      "Orignal dates\n",
+      "2022-05-29 18:20:18+00:00 2022-09-25 18:20:18+00:00\n",
+      "Updated dates\n",
+      "2022-05-29 18:21:09.000268+00:00 2022-09-25 18:21:09.000268+00:00\n",
+      "2022-05-29 18:21:09.000268+00:00 2022-09-25 18:21:09.000268+00:00\n",
+      "Orignal dates\n",
+      "2022-03-28 03:59:24+00:00 2022-09-25 18:20:23+00:00\n",
+      "Updated dates\n",
+      "2022-03-28 04:00:14.662085+00:00 2022-09-25 03:59:32.662085+00:00\n",
+      "2022-03-31 13:16:27.662085+00:00 2022-09-25 18:21:13.662085+00:00\n"
+     ]
+    }
+   ],
+   "source": [
+    "update_timestamp('registration_data_20K_full.csv')\n",
+    "\n",
+    "update_timestamp('registration_data_20K_minimum.csv')\n",
+    "\n",
+    "update_timestamp('transaction_data_100K_full.csv')\n",
+    "\n",
+    "with zipfile.ZipFile(\"ato_data_800K_full.csv.zip\",\"r\") as zip_ref:\n",
+    "    zip_ref.extractall(\".\")\n",
+    "update_timestamp('ato_data_800K_full.csv')\n",
+    "zipfile.ZipFile('ato_data_800K_full.csv.zip', mode='w').write(\"ato_data_800K_full.csv\", compress_type=zipfile.ZIP_DEFLATED)\n",
+    "os.remove('ato_data_800K_full.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8efd4cfe",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "920feedb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
*Issue #, if available:*
Amazon Fraud Detector only retain 18 months of data for ingested events. This notebook provide functions to shift dateset timestamps to most recent months. 

*Description of changes:*
Add a notebook under data folder

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
